### PR TITLE
SpoofaxWithCore/159: fix String escaping in Stratego

### DIFF
--- a/org.metaborg.meta.lang.stratego/syntax/Stratego-Sugar.def
+++ b/org.metaborg.meta.lang.stratego/syntax/Stratego-Sugar.def
@@ -673,11 +673,11 @@ module Stratego-Core-Constants
 exports
   sorts Int Real String StrChar
   lexical syntax
-    [\-]? [0-9]+ 		-> Int
-    [\-]? [0-9]+ [\.] [0-9]+ 	-> Real
-    "\"" StrChar* "\"" 		-> String
-    ~[\"\\] 			-> StrChar
-    [\\] [\"tnr\\] 		-> StrChar
+    [\-]? [0-9]+             -> Int
+    [\-]? [0-9]+ [\.] [0-9]+ -> Real
+    "\"" StrChar* "\""       -> String
+    ~[\"\\]                  -> StrChar %% add the new line character (\n) to be consistent with other languages but break backwards compatibility
+    [\\] [tnrbf\"\'\\]       -> StrChar
 
 
 module Stratego-Sugar-Constants
@@ -688,10 +688,10 @@ imports
 exports
   sorts Char CharChar
   lexical syntax
-    "'" CharChar "'"		-> Char
-    ~[\']			-> CharChar
-    [\\] [\'ntr\ ]		-> CharChar
-    Char		 	-> Id {reject}
+    "'" CharChar "'"     -> Char
+    ~[\']                -> CharChar %% add the new line and backslash characters (\n\\) to be consistent with other languages but break backwards compatibility
+    [\\] [tnrbf\"\'\\\ ] -> CharChar %% remove the space character (\ ) to be consistent with other languages but break backwards compatability
+    Char                 -> Id {reject}
 
 module Stratego-Core-Identifiers
 exports

--- a/stratego/stratego/core/constants.sdf3
+++ b/stratego/stratego/core/constants.sdf3
@@ -9,6 +9,6 @@ module stratego/core/constants
     
     String  = "\"" StrChar* "\""
     
-    StrChar = ~[\"\\] 
-    StrChar = [\\] [\"tnr\\]
+    StrChar = ~[\"\\] %% add the new line character (\n) to be consistent with other languages but break backwards compatibility
+    StrChar = [\\] [tnrbf\"\'\\]
 

--- a/stratego/stratego/sugar/constants.sdf3
+++ b/stratego/stratego/sugar/constants.sdf3
@@ -8,6 +8,6 @@ module stratego/sugar/constants
   sorts Char CharChar
   lexical syntax
     Char     = "'" CharChar "'"
-    CharChar = ~[\']		
-    CharChar = [\\] [\'ntr\ ]
+    CharChar = ~[\'] %% add the new line and backslash characters (\n\\) to be consistent with other languages but break backwards compatibility
+    CharChar = [\\] [tnrbf\"\'\\\ ] %% remove the space character (\ ) to be consistent with other languages but break backwards compatability
     Id       = Char {reject}


### PR DESCRIPTION
- optional escaping of single (double) quotes in double-(single-)quoted Strings
- support backspace (\b) and form feed (\f) characters

These changes extend Stratego such that the `String` and the `Char` in Stratego become super-classes of the `String` and the `Char` in Java (and many other languages). Let me know if you want me to make it entirely consistent with Java (i.e. not a super class nor a sub class). That would break backwards compatibility. Also see the comments I added in the code. If not this code is good to be merged.

I tested by running `./b build -st all`. Then I installed the generated update site into Eclipse and verified manually that the new escaping rules (e.g. `"\'"`) are working correctly.
