### PR TITLE
Import lib-sglr in Stratego editor analysis

### DIFF
--- a/org.metaborg.meta.lang.stratego/trans/analysis.str
+++ b/org.metaborg.meta.lang.stratego/trans/analysis.str
@@ -153,7 +153,7 @@ rules // Declare globals
 
   declare-globals-top =
     if not(NoAnalysis) then
-      with(<declare-globals> Import("libstratego-lib"));
+      with(<map(declare-globals)> [Import("libstratego-lib"), Import("libstratego-sglr")]);
       alltd(origin-track-forced(declare-globals))
     end
 


### PR DESCRIPTION
Since it's always compiled and loaded with a Stratego project in Spoofax and defines lowercase nullary constructors. Through this import the analysis is aware of this and will warn against using those nullary constructors as variable names (a common footgun, especially since lib-sglr has lowercase nullary constructors such as `left` and `right`). 