### PR TITLE
Added warning on simple matching congruences (generalising a previous warning)

### DIFF
--- a/org.metaborg.meta.lang.stratego/trans/analysis.str
+++ b/org.metaborg.meta.lang.stratego/trans/analysis.str
@@ -781,6 +781,7 @@ rules // Constraints
   strat-in-Cong(x) = ListCongNoTail(map(x))
   strat-in-Cong(x) = ListCong(map(x),x)
   strat-in-Cong(x) = ExplodeCong(x,ParenStrat(x))
+  strat-in-Cong(x) = ?CallT(SVar(_), _, _); where(is-constructor); CallT(id, map(x), id)
 
   constraint-warning:
     Import("Java-15") -> (<id>, "Use 'import libjava-front' instead")

--- a/org.metaborg.meta.lang.stratego/trans/analysis.str
+++ b/org.metaborg.meta.lang.stratego/trans/analysis.str
@@ -766,10 +766,21 @@ rules // Constraints
     where
       require(not(is-constructor))
 
-  constraint-warning:
-    CallT(SVar(<"debug" + "say">), [t], []) -> (s, $[Should be '![s]'])
-    where
-      !t => StrCong(s) + !t => IntCong(s)
+  contraint-warning-om:
+    t -> (t, $[Simple matching congruence: prefix with '?'. Or with '!' if you meant to build.])
+    where <rec x(strat-in-Cong(x))> t
+
+  strat-in-Cong(x) = ?StrCong(_)
+  strat-in-Cong(x) = ?IntCong(_)
+  strat-in-Cong(x) = ?RealCong(_)
+  strat-in-Cong(x) = ?CharCong(_)
+  strat-in-Cong(x) = CongQ(id,map(x))
+  strat-in-Cong(x) = AnnoCong(x,StrategyCurly(x))
+  strat-in-Cong(x) = ?EmptyTupleCong()
+  strat-in-Cong(x) = TupleCong(map(x))
+  strat-in-Cong(x) = ListCongNoTail(map(x))
+  strat-in-Cong(x) = ListCong(map(x),x)
+  strat-in-Cong(x) = ExplodeCong(x,ParenStrat(x))
 
   constraint-warning:
     Import("Java-15") -> (<id>, "Use 'import libjava-front' instead")

--- a/org.metaborg.meta.lang.stratego/trans/stratego_sugar.str
+++ b/org.metaborg.meta.lang.stratego/trans/stratego_sugar.str
@@ -16,21 +16,24 @@ strategies
 rules
 
   editor-analyze:
-    (ast, path, project-path) -> (ast', errors, warnings, [])
+    (ast, path, project-path) -> (ast', errors, warnings', [])
     with
       reset-dynamic-rules
     with
       ast' := <analyze-ast <+ !()> (ast, path, project-path);
       if NoAnalysis then
-        errors   := <collect-all(constraint-error, conc)> ast';
-        warnings := <collect-all(constraint-warning, conc)> ast'
+        errors    := <collect-all(constraint-error, conc)> ast';
+        warnings  := <collect-all(constraint-warning, conc)> ast';
+        warnings' := <conc> (warnings, <collect-om(contraint-warning-om, conc)> ast')
       else
         if WarnAnalysis then
-          errors   := <collect-all(constraint-error, conc)> ast';
-          warnings := <collect-all(global-constraint-error + constraint-warning, conc)> ast'
+          errors    := <collect-all(constraint-error, conc)> ast';
+          warnings  := <collect-all(global-constraint-error + constraint-warning, conc)> ast';
+          warnings' := <conc> (warnings, <collect-om(contraint-warning-om, conc)> ast')
         else
-          errors   := <collect-all(global-constraint-error + constraint-error, conc)> ast';
-          warnings := <collect-all(constraint-warning, conc)> ast'
+          errors    := <collect-all(global-constraint-error + constraint-error, conc)> ast';
+          warnings  := <collect-all(constraint-warning, conc)> ast';
+          warnings' := <conc> (warnings, <collect-om(contraint-warning-om, conc)> ast')
         end
       end
 


### PR DESCRIPTION
Previously the editor warned you when you specifically wrote `debug("message")` that you should use `debug(!"message")` instead. This is because `"message"` is in a strategy position, which makes it a congruence, both matching and building against the string literal. This warning was specialised to the `debug` strategy. I've now generalised the warning to find any congruences with only congruences as sub-strategies and put a warning on them. So if somewhere in a strategy position you use `SVar("main_0_0")` you will get a warning telling you that this is a simple matching congruence and you should prefix it with a `?` (which preserves the behaviour but it more explicit); or prefix it with a `!` if you meant to build the term. 